### PR TITLE
Fix internal QAN removal failure caused by calling a removed api

### DIFF
--- a/cmd/ssm-managed/main.go
+++ b/cmd/ssm-managed/main.go
@@ -282,11 +282,6 @@ func removeInternalQan(ctx context.Context, deps *serviceDependencies) error {
 		return err
 	}
 
-	err = deps.qan.RemoveQANData(ctx, agentService.QanDBInstanceUUID)
-	if err != nil {
-		return err
-	}
-
 	return deps.db.InTransaction(func(tx *reform.TX) error {
 		_, err = tx.DeleteFrom(models.AgentServiceView, "WHERE agent_id = ?", agentService.AgentID)
 		if err != nil {


### PR DESCRIPTION
Close https://github.com/shatteredsilicon/ssm-submodules/issues/271